### PR TITLE
Allow serialization of NumPy arrays

### DIFF
--- a/qhue.py
+++ b/qhue.py
@@ -19,9 +19,9 @@ class Resource(object):
         http_method = kwargs.pop('http_method',
             'get' if not kwargs else 'put').lower()
         if http_method == 'put':
-            r = requests.put(url, data=json.dumps(kwargs), timeout=self.timeout)
+            r = requests.put(url, data=json.dumps(kwargs, default=list), timeout=self.timeout)
         elif http_method == 'post':
-            r = requests.post(url, data=json.dumps(kwargs), timeout=self.timeout)
+            r = requests.post(url, data=json.dumps(kwargs, default=list), timeout=self.timeout)
         elif http_method == 'delete':
             r = requests.delete(url, timeout=self.timeout)
         else:


### PR DESCRIPTION
When the maintainers of [colour](http://colour-science.org) vectorized their API recently, they changed their calculation functions to return NumPy arrays instead of lists. This broke some of my existing code since I was using colour to compute the values of the xy parameter. This commit teaches qhue to try to convert previously-unserializable objects to lists.