### PR TITLE
Correctly pass the timeout value to subresources

### DIFF
--- a/qhue.py
+++ b/qhue.py
@@ -36,7 +36,7 @@ class Resource(object):
         return resp
         
     def __getattr__(self, name):
-        return Resource(self.url + "/" + str(name))
+        return Resource(self.url + "/" + str(name), timeout=self.timeout)
 
     __getitem__ = __getattr__
     


### PR DESCRIPTION
This fix should be pretty self-explanatory. I tested that it was previously incorrect by setting the timeout to 0.01 and noting that br() timed out while br.lights() incorrectly didn't.