### PR TITLE
Return part after /api/{user} when getting 'address'

### DIFF
--- a/qhue/qhue.py
+++ b/qhue/qhue.py
@@ -5,6 +5,7 @@ import requests
 import json
 # for hostname retrieval for registering with the bridge
 from socket import getfqdn
+import re
 import sys
 
 __all__ = ('Bridge', 'QhueException', 'create_new_username')
@@ -16,7 +17,7 @@ _DEFAULT_TIMEOUT = 5
 class Resource(object):
     def __init__(self, url, timeout=_DEFAULT_TIMEOUT):
         self.url = url
-        self.address = url[url.find('/api'):]
+        self.address = re.search(r'/api/[^/]*(.*)', url).group(1)
         self.timeout = timeout
 
     def __call__(self, *args, **kwargs):

--- a/qhue/qhue.py
+++ b/qhue/qhue.py
@@ -17,7 +17,8 @@ _DEFAULT_TIMEOUT = 5
 class Resource(object):
     def __init__(self, url, timeout=_DEFAULT_TIMEOUT):
         self.url = url
-        self.address = re.search(r'/api/[^/]*(.*)', url).group(1)
+        self.address = url[url.find('/api'):]
+        self.short_address = re.search(r'/api/[^/]*(.*)', url).group(1)
         self.timeout = timeout
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
In the official API documentation, the addresses used when creating rules are only the part after `/api/{user}`, e.g. `/lights/1` (as opposed to schedules, where the full address is required).
The proposed change introduces a `short_address` attribute that returns this.