### PR TITLE
Use OrderedDict to preserve object order.

### DIFF
--- a/qhue/qhue.py
+++ b/qhue/qhue.py
@@ -1,6 +1,7 @@
 # Qhue is (c) Quentin Stafford-Fraser 2017
 # but distributed under the GPL v2.
 
+import collections
 import requests
 import json
 # for hostname retrieval for registering with the bridge
@@ -42,7 +43,7 @@ class Resource(object):
             r = requests.get(url, timeout=self.timeout)
         if r.status_code != 200:
             raise QhueException("Received response {c} from {u}".format(c=r.status_code, u=url))
-        resp = r.json()
+        resp = r.json(object_pairs_hook=collections.OrderedDict)
         if type(resp) == list:
             errors = [m['error']['description'] for m in resp if 'error' in m]
             if errors:


### PR DESCRIPTION
In Python 3.7 dict is guarenteed to preserve insertion order (which was
an implementation specific detail in CPython 3.6), however earlier
versions of Python don't.

Use OrderedDict to preserve the insertion order so that iterating over
objects will return them in the same order as returned by the Hue API.

Before:
```
- 3: David's Lamp (off)
- 4: Living room lamp (off)
- 1: David's Bedside Lamp (off)
- 2: Alex's Lamp (off)
```

After:
```
- 1: David's Bedside Lamp (off)
- 2: Alex's Lamp (off)
- 3: David's Lamp (off)
- 4: Living room lamp (off)
```