### PR TITLE
Allow for escaping syntax-conflicting keyword args by appending an underscore

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ Sometimes, though, you need to specify a POST or a DELETE, and you can do so wit
     # Delete rule 1
     b('rules', 1, http_method='delete')
 
+If you need to specify a keyword argument that would conflict with a Python keyword, such as `class`, simply append an underscore to it, like this:
+
+    # Set property "class" to "Hallway".
+    # The trailing underscore will automatically be removed
+    # in the property name sent to the bridge.
+
+    b.groups[19](class_='Hallway')
+
 Finally, for certain operations, like schedules and rules, you'll want to know the 'address' of a resource, which is the absolute URL path - the bit after the IP address, or, more recently, the bit after the username.  You can get these with the `address` and `short_address` attributes:
 
     >>> b.groups[1].url

--- a/qhue/qhue.py
+++ b/qhue/qhue.py
@@ -27,11 +27,18 @@ class Resource(object):
         self.object_pairs_hook = object_pairs_hook
 
     def __call__(self, *args, **kwargs):
+        # Preprocess args and kwargs
         url = self.url
         for a in args:
             url += "/" + str(a)
         http_method = kwargs.pop('http_method',
             'get' if not kwargs else 'put').lower()
+
+        # From each keyword, strip one trailing underscore if it exists,
+        # then send them as parameters to the bridge. This allows for
+        # "escaping" of keywords that might conflict with Python syntax
+        # or with the specially-handled keyword "http_method".
+        kwargs = {(k[:-1] if k.endswith('_') else k): v for k, v in kwargs.items()}
         if http_method == 'put':
             r = requests.put(url, data=json.dumps(kwargs, default=list), timeout=self.timeout)
         elif http_method == 'post':


### PR DESCRIPTION
I took a stab at fixing Issue #23.

I wasn't able to tell which specific Python 2 and 3 versions you were targeting, so I used a dict comprehension. In case you wanted to support Pythons before dict comprehension was introduced, Line 41 of qhue.py can be replaced with the following, which does the same thing with just a list comprehension:

    kwargs = dict([(k[:-1] if k.endswith('_') else k, v) for k, v in kwargs.items()])