### PR TITLE
Use compact json representation for Hue API commands

### DIFF
--- a/qhue/qhue.py
+++ b/qhue/qhue.py
@@ -40,9 +40,9 @@ class Resource(object):
         # or with the specially-handled keyword "http_method".
         kwargs = {(k[:-1] if k.endswith('_') else k): v for k, v in kwargs.items()}
         if http_method == 'put':
-            r = requests.put(url, data=json.dumps(kwargs, default=list), timeout=self.timeout)
+            r = requests.put(url, data=json.dumps(kwargs, separators=(',', ':'), default=list), timeout=self.timeout)
         elif http_method == 'post':
-            r = requests.post(url, data=json.dumps(kwargs, default=list), timeout=self.timeout)
+            r = requests.post(url, data=json.dumps(kwargs, separators=(',', ':'), default=list), timeout=self.timeout)
         elif http_method == 'delete':
             r = requests.delete(url, timeout=self.timeout)
         else:


### PR DESCRIPTION
Certain commands in the Hue API have limits on the number of characters in the JSON representation of arguments.  This pull request makes a more compact JSON representation of the python objects by omitting spaces in the JSON.  This allows for bigger python objects to be used given the same total JSON character constraints.

The mechanism is to use the argument `separators` in `json.dumps` as described in https://docs.python.org/3/library/json.html#json.dump to create a compact JSON representation:
> To get the most compact JSON representation, you should specify (',', ':') to eliminate whitespace.

I've tried this and it also doesn't seem to break anything (it's still valid JSON).

Examples of commands with character limitations in the JSON representation are:

Create Schedule, the `body` argument in the `command` object. https://developers.meethue.com/develop/hue-api/3-schedules-api/#create-schedule 
> body | string 1..90 | JSON string to be sent to the relevant resource.

Create Rule, the `body` of an `action`.
https://developers.meethue.com/develop/hue-api/6-rules-api/#create-rule
> body | string 1..90 | JSON string to be sent to the relevant resource.

