### PR TITLE
init Exception & add __str__

### DIFF
--- a/qhue/qhue.py
+++ b/qhue/qhue.py
@@ -152,3 +152,8 @@ class QhueException(Exception):
         self.message = message
         self.type_id = type_id
         self.address = address
+
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f'QhueException: {self.type_id} -> {self.message}'

--- a/qhue/qhue.py
+++ b/qhue/qhue.py
@@ -70,8 +70,8 @@ class Resource(object):
                 # so we return the type and address of the first one in the 
                 # exception, to keep the exception type simple.
                 raise QhueException(
-                    message="\n".join(e["description"] for e in errors),
-                    type_id=errors[0]['type'], 
+                    message=",".join(e["description"] for e in errors),
+                    type_id=",".join(e["type"] for e in errors),
                     address=errors[0]['address']
                 )
         return resp

--- a/qhue/qhue.py
+++ b/qhue/qhue.py
@@ -71,7 +71,7 @@ class Resource(object):
                 # exception, to keep the exception type simple.
                 raise QhueException(
                     message=",".join(e["description"] for e in errors),
-                    type_id=",".join(e["type"] for e in errors),
+                    type_id=",".join(str(e["type"]) for e in errors),
                     address=errors[0]['address']
                 )
         return resp


### PR DESCRIPTION
Thanks for adding the type_id to the exception! It helped me deal with some 'expected' exceptions.  Since Hue sometimes returns multiple errors, I changed it to return multiple type_ids separated by commas. 

Also, I use [Rollbar](https://rollbar.com/) to report unexpected exceptions from my script, and noticed that it didn't seem to pass either 'message' or traceback to Rollbar.  I think it may be because the Exception wasn't initialized. 

This PR seems to have solved the issue for me, and I now get more meaningful reporting in rollbar. That said I'm not a python expert so I don't know if this is correct, but it seems to work for me. 