### PR TITLE
Update create_new_username to pass a session object

### DIFF
--- a/qhue/qhue.py
+++ b/qhue/qhue.py
@@ -105,7 +105,8 @@ def create_new_username(ip, devicetype=None, timeout=_DEFAULT_TIMEOUT):
         QhueException if something went wrong with username generation (for
             example, if the bridge button wasn't pressed).
     """
-    res = Resource(_local_api_url(ip), timeout)
+    session = requests.Session()
+    res = Resource(_local_api_url(ip), session, timeout)
     prompt = "Press the Bridge button, then press Return: "
     input(prompt)
 


### PR DESCRIPTION
Im guessing the signature to Resource changed at some point to accept a
session as the second argument.  This PR updates create_new_username to
create and pass a session object