### PR TITLE
Prevent accidental iteration on Bridge/Resource (avoid infinite loop & memory exhaustion)

### DIFF
--- a/qhue/qhue.py
+++ b/qhue/qhue.py
@@ -86,6 +86,9 @@ class Resource(object):
 
     __getitem__ = __getattr__
 
+    def __iter__(self):
+        raise TypeError(f"'{type(self)}' object is not iterable")
+
 
 def _local_api_url(ip, username=None):
     if username is None:


### PR DESCRIPTION
This is just a small proposal to disallow accidental iteration on raw Bridge/Resource objects, which will result in an infinite loop and potentially other dramatic effects such as system memory exhaustion.

Because the Resource class (and Bridge via inheritance) defines \_\_getitem\_\_, Python assumes by default that the object is iterable. In the absence of \_\_iter\_\_, it treats the object like a list, requesting values 0, 1, 2, etc. Since Bridge and Resource accept any and all \_\_getitem\_\_ requests, this process never ends. As the following example shows, this can easily trigger runaway memory usage, which many OSs handle notoriously poorly.

Consider the following, which gets a list of light IDs:

```
import qhue
qb = qhue.Bridge('hue.lan', '<username>')
list(qb.lights())
```

If this typo is made, Python will chew up all available memory on the system:

```
# The following will cause an out-of-memory condition
import qhue
qb = qhue.Bridge('hue.lan', '<username>')
list(qb.lights)                    # Whoops! Missing '()' after 'qb.lights'
```

And yes, this has happened to me on a few occasions. :-)

This patch protects against this by simply defining a \_\_iter\_\_ method on Resource that raises a TypeError indicating that iteration is inappropriate, just as non-iterable native Python types do. Since iterating on a raw Resource (as opposed to the iterable values it returns when actually called) doesn't make much semantic sense, I think this is a reasonable and desirable thing to do.