### PR TITLE
Supporting Hue API v2

### DIFF
--- a/qhue/__init__.py
+++ b/qhue/__init__.py
@@ -1,2 +1,2 @@
-from .qhue import Bridge, QhueException, create_new_username
+from .qhue import Bridge, QhueException, Bridge_APIv2, QhueException_APIv2, create_new_username
 from .qhue_remote import RemoteBridge

--- a/qhue/qhue.py
+++ b/qhue/qhue.py
@@ -10,7 +10,9 @@ from socket import getfqdn
 
 import requests
 
-__all__ = ("Bridge", "QhueException", "create_new_username")
+__all__ = ("Bridge", "QhueException",
+           "Bridge_APIv2", "QhueException_APIv2",
+           "create_new_username")
 
 # default timeout in seconds
 _DEFAULT_TIMEOUT = 5


### PR DESCRIPTION
Here is a WIP attempt to add support for the upcoming version 2 of the Philips Hue API to qhue. Feedback and collaboration welcome. :-) Version 2 of the API is currently in early access, not yet feature complete, but Philips intends to someday have it replace the existing version 1.

In this draft, access to the new API is implemented via the provisionally-named Bridge_APIv2 and Resource_APIv2 classes. Due to differences in how the v2 API reports errors, these also use a separate exception class, QhueException_APIv2, which implements a different set of properties. The original Bridge and QhueException objects are still available for API v1 access, since some functionality is only available in v1 at the moment; their semantics should be unchanged. For now, it seems that v2 uses the same usernames (now called application keys), so the existing create_new_username function should work for both versions of the API (though at the moment it still uses the unencrypted HTTP connection).

Key differences of the new API include:
* HTTPS is mandatory; no more HTTP support
* A different root URL (/clip/v2 instead of /api/\<username\>)
* Application usernames/keys are passed as an HTTP header rather than being part of the URL
* Completely reworked resource paths and semantics
* HTTP response codes are used to report all errors, and response bodies include the top-level JSON items “errors” which lists any errors and “data” for all other information.

At this point, basic GETs and PUTs to the new API appear to work, though more thorough testing needs to be done.

Other work left to do:

**HTTPS certificate validation:** I'm not too knowledgeable with TLS matters, so this is the most difficult problem for me. The requests module will complain about the bridge's HTTPS certificate because it will not recognize the root CA. Furthermore, it expects the domain name to match that specified in the certificate (which will be the bridge's ID), and this will almost certainly not be the case on a typical user's home network. Further complicating matters is that some bridges still use the older self-signed certificates rather than the newer ones Philips says they'll eventually be rolling out, so this will also need to be handled.

Philips suggests implementing a custom domain name verifier that checks the bridge ID (which still needs to be initially obtained somehow) against that in the certificate. I do not yet know how this can be done with requests. For testing purposes, I've for now disabled certificate validation (and squelched the resulting warning message), but this is something we probably want to do properly at some point. If anyone knows how to make this work without severely hurting usability, I'm all ears. :-)

**Event stream support:** API v2 has a new event stream that apps can subscribe to to be notified about changes on the bridge. This would probably be best implemented using a different sort of class, or perhaps as a callback. I haven't looked into this yet.

**Remote API support:** I have never used this personally, so I don't know yet how this works with respect to v2.

**Examples and documentation, etc., for the newer API**
