### PR TITLE
Fix: remote bridge responding with 415 for PUT and POST

### DIFF
--- a/qhue/qhue_remote.py
+++ b/qhue/qhue_remote.py
@@ -70,6 +70,7 @@ class RemoteBridge(Resource):
         """
         # Use an oauth session in place of a standard requests session.
         self.session = OAuth2Session(client_id, token=token)
+        self.session.headers["Content-Type"] = "application/json"
         if token is not None:
             return token
         authorization_url, state = self.session.authorization_url(OAUTH_AUTHORIZE_URL)


### PR DESCRIPTION
When using a remote connection, everything went fine until I tried to modify the state of the room.
The hue server responded with 415 (Unsupported Media Type).
I saw that it could be because of the lack of "Content-Type" header, and indeed adding it solve the issue in my case.